### PR TITLE
Regata/fix fee estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The pay to open channel protocol consists of 4 steps performed between a **Taker
 4. Maker verifies that PSBT and the included funding transaction are correct. They also check that there is a pending channel with the Taker that points to the funding transaction and has the right balances between Maker and Taker<sup>3</sup>. They sign their inputs, finalize PSBT and publish the funding transaction. After the funding transaction is confirmed, the channel is fully open and active.
 
 
-<sup>1</sup> Currently this fee is paid by the Taker, however the protocol can support splitting the fee between 2 participants
+<sup>1</sup> Currently this tx fee is split between Taker and Maker where each side pays for their own inputs and outputs. Additionally, Taker pays the portion of fees to cover the funding output (2-2 multisig) of the transaction.
 
 <sup>2</sup> In the most basic case the funding transaction will look the following:
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The pay to open channel protocol consists of 4 steps performed between a **Taker
 4. Maker verifies that PSBT and the included funding transaction are correct. They also check that there is a pending channel with the Taker that points to the funding transaction and has the right balances between Maker and Taker<sup>3</sup>. They sign their inputs, finalize PSBT and publish the funding transaction. After the funding transaction is confirmed, the channel is fully open and active.
 
 
-<sup>1</sup> Currently this tx fee is split between Taker and Maker where each side pays for their own inputs and outputs. Additionally, Taker pays the portion of fees to cover the funding output (2-2 multisig) of the transaction.
+<sup>1</sup> Currently this tx fee is split between Taker and Maker where each side pays for their own inputs and outputs.
 
 <sup>2</sup> In the most basic case the funding transaction will look the following:
 

--- a/p2oc/__init__.py
+++ b/p2oc/__init__.py
@@ -84,7 +84,7 @@ def accept_offer(offer_psbt, lnd):
 
     # This is to obtain our UTXOs
     allocated_psbt = p2oc_wallet.allocate_funds(
-        offer.fund_amount, lnd, include_tx_fee=False
+        offer.fund_amount, lnd, include_tx_fee=True
     )
     p2oc_psbt.merge_psbts(from_psbt=allocated_psbt, to_psbt=offer_psbt)
 

--- a/p2oc/__init__.py
+++ b/p2oc/__init__.py
@@ -21,24 +21,11 @@ from p2oc import offer as p2oc_offer
 from p2oc import psbt as p2oc_psbt
 from bitcoin.rpc import unhexlify
 
-CHANNEL_FUNDING_OUTPUT_SIZE = 43  # vout size in vbytes of the 2-2 multisig output
-
 
 def create_offer(premium_amount, fund_amount, lnd):
-    # estimate how much offer creator should allocate in additional tx fees the channel funding output
-    sat_per_vbyte = p2oc_wallet.estimate_fee(lnd)
-    funding_output_fee = sat_per_vbyte * CHANNEL_FUNDING_OUTPUT_SIZE
-
-    # allocate funds for the premium and "funding output fee"
-    psbt = p2oc_wallet.allocate_funds(
-        premium_amount + funding_output_fee, lnd, include_tx_fee=True
-    )
-
-    # "move" funding_output_fee from change output into actual tx fee
-    tx = bc.CMutableTransaction.from_instance(psbt.unsigned_tx)
-    assert len(tx.vout) == 1
-    tx.vout[0].nValue -= funding_output_fee
-    psbt.unsigned_tx = tx
+    # allocate funds for the premium and the portion of the funding tx fees to
+    # "pay" for inputs and outputs that belong to the Taker
+    psbt = p2oc_wallet.allocate_funds(premium_amount, lnd, include_tx_fee=True)
 
     key_desc = p2oc_address.derive_next_multisig_key_desc(lnd)
     node_info = lnd.lnd.GetInfo(lnmsg.GetInfoRequest())
@@ -97,7 +84,8 @@ def accept_offer(offer_psbt, lnd):
         node_pubkey=offer.node_pubkey, node_host=offer.node_host, lnd=lnd
     )
 
-    # This is to obtain our UTXOs
+    # allocate funds for the funding amount and the portion of the funding tx
+    # fees to "pay" for inputs and outputs that belong to the Maker
     allocated_psbt = p2oc_wallet.allocate_funds(
         offer.fund_amount, lnd, include_tx_fee=True
     )

--- a/p2oc/wallet.py
+++ b/p2oc/wallet.py
@@ -66,7 +66,7 @@ def allocate_funds(amount, lnd, include_tx_fee=True, min_confirmations=6):
 
 
 def estimate_fee(lnd, conf_target=6):
-    fee_req = walletmsg.EstimateFeeRequest(conf_target=6)
+    fee_req = walletmsg.EstimateFeeRequest(conf_target=conf_target)
     resp = lnd.wallet.EstimateFee(fee_req)
     sat_per_vbyte = resp.sat_per_kw * 4 / 1000  # 1 vbyte = 4 weight units
     return int(sat_per_vbyte)

--- a/p2oc/wallet.py
+++ b/p2oc/wallet.py
@@ -6,10 +6,16 @@ from .address import create_dummy_p2wpkh_address
 
 
 def allocate_funds(amount, lnd, include_tx_fee=True, min_confirmations=6):
-    """Create a PSBT via the provided LND's wallet. The PSBT will be unsigned and have
-    a single output to the change address. The PSBT fee (difference between input and
-    output amount) will be of the given amount + the tx fee to publish this PSBT.
-    Including tx fee is configurable so as to have this or the other party pay fees.
+    """Create a PSBT via the provided LND's wallet. The PSBT will be unsigned
+    and have a single output to the change address. This PSBT secures enough
+    funds at its inputs such that later when an additional output with the given
+    `amount` is attached and the final tx will have sufficient fees.
+
+    Setting `include_tx_fee=True` will include regular tx fee calculated by
+    the wallet based on the current on-chain fees, the size of all inputs and 2
+    outputs (dummy + change)
+
+    `min_confirmations` is passed to the wallet and used for fee calculation.
     """
     # TODO: In the future refactor to explicitly create a placeholder output w/ a null
     #       output but correct value. We will change the output address later.

--- a/p2oc/wallet.py
+++ b/p2oc/wallet.py
@@ -63,3 +63,10 @@ def allocate_funds(amount, lnd, include_tx_fee=True, min_confirmations=6):
         )
 
     return psbt
+
+
+def estimate_fee(lnd, conf_target=6):
+    fee_req = walletmsg.EstimateFeeRequest(conf_target=6)
+    resp = lnd.wallet.EstimateFee(fee_req)
+    sat_per_vbyte = resp.sat_per_kw * 4 / 1000  # 1 vbyte = 4 weight units
+    return int(sat_per_vbyte)


### PR DESCRIPTION
* enable offer acceptor to pay their portion of tx fees
* offer creator estimates and pays a portion of tx fees responsible for funding output